### PR TITLE
feature(relay): add transfer struct to store announced transfers

### DIFF
--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -2,6 +2,7 @@ pub mod appstate;
 pub mod client;
 pub mod room;
 pub mod server;
+pub mod transfer;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/relay/transfer.rs
+++ b/src/relay/transfer.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Transfer {
+    pub name: String,
+    pub ip: String,
+    pub room_id: String,
+}
+
+impl Transfer {
+    pub fn new(name: String, ip: String, room_id: String) -> Self {
+        Self { name, ip, room_id }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let transfer = Transfer {
+            name: "Test".to_string(),
+            ip: "127.0.0.1".to_string(),
+            room_id: "This_is_a_test_room_id".to_string(),
+        };
+        assert_eq!(
+            Transfer::new(
+                "Test".to_string(),
+                "127.0.0.1".to_string(),
+                "This_is_a_test_room_id".to_string()
+            ),
+            transfer
+        )
+    }
+}


### PR DESCRIPTION
## Description

Added a new struct for storing informations about transfers.

## Motivation and Context

In order to distinguish between a direct and a relay transfer, the server must be able to know which transfers exist. This new struct was introduced for this purpose.

## How Has This Been Tested?

Be creating a unit test for the new structs new funtion.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing!   -->
