### PR TITLE
76 add transfer struct to appstate

### DIFF
--- a/src/relay/appstate.rs
+++ b/src/relay/appstate.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 
 use crate::relay::room::Room;
+use crate::relay::transfer::Transfer;
 
 /// A struct that holds all of the rooms that the server knows about.
 ///
@@ -11,6 +12,7 @@ use crate::relay::room::Room;
 #[derive(Debug)]
 pub struct AppState {
     pub rooms: HashMap<String, Room>,
+    pub transfers: Vec<Transfer>,
 }
 
 impl AppState {
@@ -44,15 +46,15 @@ impl AppState {
         Arc::new(RwLock::new(AppState {
             // Initialize the list of rooms to be empty.
             rooms: HashMap::new(),
+            transfers: Vec::new(),
         }))
     }
-
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc};
+    use std::sync::Arc;
 
     #[test]
     fn test_new() {

--- a/src/relay/client.rs
+++ b/src/relay/client.rs
@@ -491,6 +491,5 @@ impl Client {
 // TODO: Add tests
 #[cfg(test)]
 mod tests {
-    use super::*;
-
+    // use super::*;
 }


### PR DESCRIPTION
## Description

Added the Transfer struct to AppState.

## Motivation and Context

To keep hold of all transfers and share them between connections, it is necessary to add the transfer struct to the AppState.
Closes #76 .

## How Has This Been Tested?

Adapted unit test for creating new AppState.
Additionally tested manually.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing!   -->
