### PR TITLE
63 implement a route for deleting transfers on the relay server

### DIFF
--- a/src/relay/appstate.rs
+++ b/src/relay/appstate.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
 
 use crate::relay::room::Room;
+use crate::relay::transfer::Transfer;
 
 /// A struct that holds all of the rooms that the server knows about.
 ///
@@ -11,6 +12,7 @@ use crate::relay::room::Room;
 #[derive(Debug)]
 pub struct AppState {
     pub rooms: HashMap<String, Room>,
+    pub transfers: Vec<Transfer>,
 }
 
 impl AppState {
@@ -44,15 +46,15 @@ impl AppState {
         Arc::new(RwLock::new(AppState {
             // Initialize the list of rooms to be empty.
             rooms: HashMap::new(),
+            transfers: Vec::new(),
         }))
     }
-
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc};
+    use std::sync::Arc;
 
     #[test]
     fn test_new() {

--- a/src/relay/client.rs
+++ b/src/relay/client.rs
@@ -491,6 +491,5 @@ impl Client {
 // TODO: Add tests
 #[cfg(test)]
 mod tests {
-    use super::*;
-
+    // use super::*;
 }

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -2,6 +2,7 @@ pub mod appstate;
 pub mod client;
 pub mod room;
 pub mod server;
+pub mod transfer;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/relay/transfer.rs
+++ b/src/relay/transfer.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Transfer {
+    pub name: String,
+    pub ip: String,
+    pub room_id: String,
+}
+
+impl Transfer {
+    pub fn new(name: String, ip: String, room_id: String) -> Self {
+        Self { name, ip, room_id }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let transfer = Transfer {
+            name: "Test".to_string(),
+            ip: "127.0.0.1".to_string(),
+            room_id: "This_is_a_test_room_id".to_string(),
+        };
+        assert_eq!(
+            Transfer::new(
+                "Test".to_string(),
+                "127.0.0.1".to_string(),
+                "This_is_a_test_room_id".to_string()
+            ),
+            transfer
+        )
+    }
+}

--- a/src/sender/mod.rs
+++ b/src/sender/mod.rs
@@ -39,6 +39,7 @@
 /// The `start` function takes ownership of the `WebSocketStream` and the file
 /// paths, so we pass it the `paths` vector by value.
 pub mod client;
+pub mod util;
 
 use crate::sender::client as sender;
 use tokio_tungstenite::{

--- a/src/sender/util.rs
+++ b/src/sender/util.rs
@@ -1,0 +1,39 @@
+use rand::{seq::SliceRandom, thread_rng};
+
+fn generate_random_name() -> String {
+    let mut rng = thread_rng();
+    let adjective = adjectives().choose(&mut rng).unwrap();
+    // let adjective = adjectives().sample(&mut rng).unwrap();
+    let noun1 = nouns1().choose(&mut rng).unwrap();
+    let noun2 = nouns2().choose(&mut rng).unwrap();
+
+    format!("{adjective}-{noun1}-{noun2}")
+}
+
+fn adjectives() -> &'static [&'static str] {
+    static ADJECTIVES: &[&str] = &["funny", "smart", "creative", "friendly", "great"];
+    ADJECTIVES
+}
+
+fn nouns1() -> &'static [&'static str] {
+    static NOUNS1: &[&str] = &["dog", "cat", "flower", "tree", "house"];
+    NOUNS1
+}
+
+fn nouns2() -> &'static [&'static str] {
+    static NOUNS2: &[&str] = &["cookie", "cake", "frosting"];
+    NOUNS2
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_random_name() {
+        let name = generate_random_name();
+
+        assert!(name.contains('-'));
+        assert!(name.split('-').count() == 3);
+        assert!(name.len() > 0);
+    }
+}

--- a/src/shuttle.rs
+++ b/src/shuttle.rs
@@ -1,5 +1,6 @@
 use crate::relay::appstate::AppState;
 use crate::relay::server::download_info;
+use crate::relay::server::download_success;
 use crate::relay::server::upload_info;
 use crate::relay::server::ws_handler;
 use axum::{
@@ -24,6 +25,7 @@ async fn axum() -> ShuttleAxum {
         .route("/ws", get(ws_handler))
         .route("/upload", post(upload_info))
         .route("/download/:name", get(download_info))
+        .route("/download_success/:name", post(download_success))
         .with_state(appstate)
         .layer(SecureClientIpSource::ConnectInfo.into_extension());
 

--- a/src/shuttle.rs
+++ b/src/shuttle.rs
@@ -1,6 +1,10 @@
 use crate::relay::appstate::AppState;
+use crate::relay::server::upload_info;
 use crate::relay::server::ws_handler;
-use axum::{routing::get, Router};
+use axum::{
+    routing::{get, post},
+    Router,
+};
 use axum_client_ip::SecureClientIpSource;
 use shuttle_axum::ShuttleAxum;
 
@@ -17,6 +21,7 @@ async fn axum() -> ShuttleAxum {
     // Set up the application routes.
     let app = Router::new()
         .route("/ws", get(ws_handler))
+        .route("/upload", post(upload_info))
         .with_state(appstate)
         .layer(SecureClientIpSource::ConnectInfo.into_extension());
 

--- a/src/shuttle.rs
+++ b/src/shuttle.rs
@@ -1,4 +1,5 @@
 use crate::relay::appstate::AppState;
+use crate::relay::server::download_info;
 use crate::relay::server::upload_info;
 use crate::relay::server::ws_handler;
 use axum::{
@@ -22,6 +23,7 @@ async fn axum() -> ShuttleAxum {
     let app = Router::new()
         .route("/ws", get(ws_handler))
         .route("/upload", post(upload_info))
+        .route("/download/:name", get(download_info))
         .with_state(appstate)
         .layer(SecureClientIpSource::ConnectInfo.into_extension());
 


### PR DESCRIPTION
## Description

Added a route to delete successful transfers from the relay server

## Motivation and Context

To keep the system clean it is necessary to remove old transfers.

Closes #63 

## How Has This Been Tested?

This was manually tested against a local test setup and the shuttle setup.
The used commands were:

```bash
curl -X POST -H "Content-Type: application/json" -d '{"name": "my_file.txt","ip":"192.168.1.100","room_id":"my_room"}' http://localhost:8000/upload
```
```bash
curl http://localhost:8000/download/my_file.txt
```
```bash
curl -X POST http://localhost:8000/download_success/my_file.txt
```

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing!   -->
